### PR TITLE
patch: Update base image to use latest debian

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 # base-image for python on any machine using a template variable,
 # see more about dockerfile templates here: https://www.balena.io/docs/learn/develop/dockerfile/
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3-stretch-run
+FROM balenalib/%%BALENA_ARCH%%-python:3-run
 
 # use `install_packages` if you need to install dependencies,
 # for instance if you need git, just uncomment the line below.
@@ -19,7 +19,7 @@ RUN pip install -r requirements.txt
 COPY . ./
 
 # Enable udevd so that plugged dynamic hardware devices show up in our container.
-ENV UDEV=1
+# ENV UDEV=1
 
 # main.py will run when container starts up on the device
 CMD ["python","-u","src/app.py"]


### PR DESCRIPTION
Private DTs do not have base images, so switching
to using images by arch simplifies automated
testing for them.

We also remove UDEV since it's not needed
for this particular application and throws
the following warning in the application logs:

`balena-hello-world Unable to start udev, container must be run in privileged mode to start udev!`