### PR TITLE
patch: Replace base image with Docker Official base image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,10 +1,5 @@
-# base-image for python on any machine using a template variable,
 # see more about dockerfile templates here: https://www.balena.io/docs/learn/develop/dockerfile/
-FROM balenalib/%%BALENA_ARCH%%-python:3-run
-
-# use `install_packages` if you need to install dependencies,
-# for instance if you need git, just uncomment the line below.
-# RUN install_packages git
+FROM python:3.13-slim-bookworm
 
 # Set our working directory
 WORKDIR /usr/src/app
@@ -17,9 +12,6 @@ RUN pip install -r requirements.txt
 
 # This will copy all files in our root to the working  directory in the container
 COPY . ./
-
-# Enable udevd so that plugged dynamic hardware devices show up in our container.
-# ENV UDEV=1
 
 # main.py will run when container starts up on the device
 CMD ["python","-u","src/app.py"]


### PR DESCRIPTION
Replacing balenalib base image in favor of Docker official image
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
